### PR TITLE
Add BTC price monitor script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# BTC Price Monitor
+
+This repository includes a simple Python script to monitor Bitcoin (BTC) price changes.
+
+## Usage
+
+1. Ensure you have Python 3 installed.
+2. Run the script:
+
+```bash
+python3 scripts/btc_monitor.py
+```
+
+The script fetches the current BTC price in USD from the CoinDesk API every minute and prints the price difference from the previous check.

--- a/scripts/btc_monitor.py
+++ b/scripts/btc_monitor.py
@@ -1,0 +1,32 @@
+import json
+import time
+import urllib.request
+
+API_URL = 'https://api.coindesk.com/v1/bpi/currentprice/BTC.json'
+
+
+def fetch_price():
+    with urllib.request.urlopen(API_URL) as response:
+        data = json.load(response)
+        return float(data['bpi']['USD']['rate_float'])
+
+
+def monitor(interval=60):
+    last_price = None
+    while True:
+        try:
+            price = fetch_price()
+            if last_price is not None:
+                diff = price - last_price
+                symbol = '↑' if diff > 0 else '↓' if diff < 0 else '-'
+                print(f"BTC price: ${price:.2f} ({symbol}{diff:+.2f})")
+            else:
+                print(f"BTC price: ${price:.2f}")
+            last_price = price
+        except Exception as e:
+            print(f"Error fetching price: {e}")
+        time.sleep(interval)
+
+
+if __name__ == '__main__':
+    monitor()


### PR DESCRIPTION
## Summary
- add simple Python script to fetch BTC price periodically
- document how to run the script in README

## Testing
- `python3 -m py_compile scripts/btc_monitor.py`
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684fb8044d8c832590214107c071098a